### PR TITLE
bump reqwest to make it compile with openssl 1.1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Gökberk Yaltıraklı <webdosusb@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-reqwest = "0.8"
+reqwest = "0.9"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
rawquest 0.8 depends on hyper-tls which depends on native-tls which depends on rust-openssl 0.9x, which is too old and cant work with recent openssl