### PR TITLE
ipfs: Fix for latest IPFS API language

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -34,7 +34,8 @@ impl IpfsApi {
         url.query_pairs_mut()
             .append_pair("arg", hash);
 
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
         Ok(resp.bytes().filter(|x|x.is_ok()).map(|x|x.unwrap()))
     }
 }

--- a/src/cat.rs
+++ b/src/cat.rs
@@ -22,7 +22,9 @@ impl IpfsApi {
         url.set_path("api/v0/cat");
         url.query_pairs_mut()
             .append_pair("arg", hash);
-        let resp = reqwest::get(url)?;
+
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
         Ok(resp.bytes().filter(|x|x.is_ok()).map(|x|x.unwrap()))
     }
 }

--- a/src/ipns.rs
+++ b/src/ipns.rs
@@ -18,7 +18,8 @@ impl IpfsApi {
     /// ```
     pub fn name_resolve(&self, name: &str) -> Result<String, Error> {
         let url = format!("http://{}:{}/api/v0/name/resolve?arg={}", self.server, self.port, name);
-        let resp = reqwest::get(&url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(&url).send()?;
         let resp: Value = serde_json::from_reader(resp)?;
         
         if resp["Path"].is_string() {
@@ -31,7 +32,8 @@ impl IpfsApi {
     /// Publish an IPFS hash in IPNS.
     pub fn name_publish(&self, hash: &str) -> Result<(), Error> {
         let url = format!("http://{}:{}/api/v0/name/publish?arg={}", self.server, self.port, hash);
-        let _resp = reqwest::get(&url)?;
+        let client = reqwest::Client::new();
+        let _resp = client.post(&url).send()?;
         Ok(())
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -13,7 +13,8 @@ impl IpfsApi {
     pub fn log_tail(&self) -> Result<impl Iterator<Item=Value>, Error> {
         let mut url = self.get_url()?;
         url.set_path("api/v0/log/tail");
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
 
         let messages = BufReader::new(resp).lines()
             .filter(|x|x.is_ok())

--- a/src/object.rs
+++ b/src/object.rs
@@ -44,7 +44,8 @@ impl IpfsApi {
     /// of a hash.
     pub fn object_stats(&self, hash: &str) -> Result<ObjectStats, Error> {
         let url = format!("http://{}:{}/api/v0/object/stat?arg={}", self.server, self.port, hash);
-        let resp = reqwest::get(&url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(&url).send()?;
         Ok(serde_json::from_reader(resp)?)
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -35,7 +35,8 @@ impl IpfsApi {
             .append_pair("arg", hash)
             .append_pair("recursive", &recursive.to_string())
             .append_pair("progress", "false");
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
         Ok(serde_json::from_reader(resp)?)
     }
 
@@ -46,7 +47,8 @@ impl IpfsApi {
         url.query_pairs_mut()
             .append_pair("arg", hash)
             .append_pair("recursive", &recursive.to_string());
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
         Ok(serde_json::from_reader(resp)?)
     }
 
@@ -55,7 +57,8 @@ impl IpfsApi {
     pub fn pin_list(&self) -> Result<Vec<PinnedHash>, Error> {
         let mut url = self.get_url()?;
         url.set_path("api/v0/pin/ls");
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
         let json_resp: serde_json::Value = serde_json::from_reader(resp)?;
 
         let mut hashes = Vec::new();

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -54,7 +54,8 @@ impl IpfsApi {
         url.query_pairs_mut()
             .append_pair("arg", channel)
             .append_pair("discover", "true");
-        let resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(url).send()?;
 
         let messages = BufReader::new(resp).lines()
             .filter(|x|x.is_ok())
@@ -82,7 +83,8 @@ impl IpfsApi {
         url.query_pairs_mut()
             .append_pair("arg", channel)
             .append_pair("arg", data);
-        let _resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let _resp = client.post(url).send()?;
         Ok(())
     }
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -9,7 +9,8 @@ impl IpfsApi {
     pub fn shutdown(&self) -> Result<(), Error> {
         let mut url = self.get_url()?;
         url.set_path("api/v0/shutdown");
-        let _resp = reqwest::get(url)?;
+        let client = reqwest::Client::new();
+        let _resp = client.post(url).send()?;
         Ok(())
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -18,7 +18,8 @@ impl IpfsApi {
     /// Get the version from the IPFS daemon.
     pub fn version(&self) -> Result<IpfsVersion, Error> {
         let url = format!("http://{}:{}/api/v0/version", self.server, self.port);
-        let resp = reqwest::get(&url)?;
+        let client = reqwest::Client::new();
+        let resp = client.post(&url).send()?;
         Ok(serde_json::from_reader(resp)?)
     }
 }


### PR DESCRIPTION
* Fixes library to work with latest API version
  from IPFS. The API requests all changed to POST from GET
  (even where POST doesn't make sense)
* Interesting IPFS completely changed the API, but didn't
  bump v0 to v1 :-|
* This breaks compatibility with any old versions
 (0.9.0 or before) but makes the crate work with recent
 versions (0.10.0 - 0.13.0)